### PR TITLE
Fix #1 XP Book in all creative tabs

### DIFF
--- a/src/main/java/zairus/xpbook/item/ItemXPBook.java
+++ b/src/main/java/zairus/xpbook/item/ItemXPBook.java
@@ -126,9 +126,12 @@ public class ItemXPBook extends XPBItem
 	@SideOnly(Side.CLIENT)
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> items)
 	{
-		ItemStack stack = new ItemStack(this);
-		stack.setItemDamage(TOTAL_CAPACITY);
-		items.add(stack);
+		if(tab == XPBook.mainTab)
+		{
+			ItemStack stack = new ItemStack(this);
+			stack.setItemDamage(TOTAL_CAPACITY);
+			items.add(stack);
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
This restricts the damaged (zero-xp) XP Book to just the XP Book creative tab.