### PR TITLE
Fix a possible XP multiplication exploit

### DIFF
--- a/src/main/java/zairus/xpbook/item/ItemXPBook.java
+++ b/src/main/java/zairus/xpbook/item/ItemXPBook.java
@@ -65,6 +65,10 @@ public class ItemXPBook extends XPBItem
 			return result;
 		
 		ItemStack book = player.getHeldItem(hand);
+		
+		if (book.stackSize != 1)
+			return result;
+		
 		int damage = book.getItemDamage();
 		
 		int curLevel = player.experienceLevel;


### PR DESCRIPTION
Some mods allow for stacking of usually unstackable items such as full XP books.

If using stacked XP books while not sneaking, the user will only empty one book but will gain the XP of the entire stack of XP books. Such behavior is exploitable in mod packs that combine the XPBook mod with mods that allow stacking of usually unstackable items.

The change presented fixes the exploit, by cancelling the interaction with the book held if the user has any amount of books in their hand other than just the one.